### PR TITLE
use keydown instead of keypress

### DIFF
--- a/main.js
+++ b/main.js
@@ -237,7 +237,7 @@ function checkRow() {
 
 // Win State:
 function winGame() {
-    window.removeEventListener("keypress", inputHandler);
+    window.removeEventListener("keydown", inputHandler);
     // HTML win screen:
     endScreen.style.display = "flex";
     if (currentRow==0) { endScreen.textContent = `Wow! You guessed ${nameArray[ran]} in 1 try!`; } 
@@ -254,7 +254,7 @@ function winGame() {
 // Loss State:
 function loseGame() {
     console.log("You Lose!")
-    window.removeEventListener("keypress", inputHandler);
+    window.removeEventListener("keydown", inputHandler);
     // HTML win screen:
     endScreen.style.display = "flex";
     endScreen.textContent = `Ach! Unfortunately you didn't guess the Pokemon`;
@@ -283,7 +283,7 @@ async function startGame() {
 
     // Pokemon Name fetch request:
     await fetchNames();
-    window.addEventListener("keypress", inputHandler);
+    window.addEventListener("keydown", inputHandler);
 
     // Random pick:
     ran = Math.floor(Math.random()*809);


### PR DESCRIPTION
Currently, backspace doesn't work in all browsers. This commit updates to set the event listener on keydown instead of keypress.

Keypress is deprecated, and keydown is a more robust event to ccapture key events.

https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event